### PR TITLE
fix: filter array of songs in setItems (DownloadHorizontalAdapter)

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/DownloadHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/DownloadHorizontalAdapter.java
@@ -80,7 +80,7 @@ public class DownloadHorizontalAdapter extends RecyclerView.Adapter<DownloadHori
         this.filterKey = filterKey;
         this.filterValue = filterValue;
 
-        this.songs = filterSong(filterKey, filterValue, songs);
+        this.songs = songs;
         this.grouped = groupSong(songs);
 
         notifyDataSetChanged();
@@ -261,7 +261,7 @@ public class DownloadHorizontalAdapter extends RecyclerView.Adapter<DownloadHori
 
             switch (view) {
                 case Constants.DOWNLOAD_TYPE_TRACK:
-                    bundle.putParcelableArrayList(Constants.TRACKS_OBJECT, new ArrayList<>(songs));
+                    bundle.putParcelableArrayList(Constants.TRACKS_OBJECT, new ArrayList<>(grouped));
                     bundle.putInt(Constants.ITEM_POSITION, getBindingAdapterPosition());
                     click.onMediaClick(bundle);
                     break;

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/DownloadHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/DownloadHorizontalAdapter.java
@@ -80,7 +80,7 @@ public class DownloadHorizontalAdapter extends RecyclerView.Adapter<DownloadHori
         this.filterKey = filterKey;
         this.filterValue = filterValue;
 
-        this.songs = songs;
+        this.songs = filterSong(filterKey, filterValue, songs);
         this.grouped = groupSong(songs);
 
         notifyDataSetChanged();


### PR DESCRIPTION
Here's another small patch of an issue that I missed yesterday.

If the download view is sorted by album, artist, genre, or year, tapping on a song can start playing the wrong song in some cases. The `songs` member variable still seems to contain the full list of downloaded songs, even when the user navigates to a subcategory that needs to be filtered

https://github.com/CappielloAntonio/tempo/assets/38386967/a3ed93a0-a399-4731-9bc9-9b7249370dd6


