### PR TITLE
Fix placeholder layouts not being visible + background color consistency

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/glide/CustomGlideRequest.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/glide/CustomGlideRequest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.util.Log;
+import android.util.TypedValue;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.content.res.AppCompatResources;
@@ -21,7 +22,6 @@ import com.cappielloantonio.tempo.App;
 import com.cappielloantonio.tempo.R;
 import com.cappielloantonio.tempo.util.Preferences;
 import com.cappielloantonio.tempo.util.Util;
-import com.google.android.material.elevation.SurfaceColors;
 
 import java.util.Map;
 
@@ -45,7 +45,7 @@ public class CustomGlideRequest {
 
     public static RequestOptions createRequestOptions(Context context, String item, ResourceType type) {
         return new RequestOptions()
-                .placeholder(new ColorDrawable(SurfaceColors.SURFACE_5.getColor(context)))
+                .placeholder(getPlaceholder(context, ResourceType.Unknown))
                 .fallback(getPlaceholder(context, type))
                 .error(getPlaceholder(context, type))
                 .diskCacheStrategy(DEFAULT_DISK_CACHE_STRATEGY)
@@ -72,7 +72,9 @@ public class CustomGlideRequest {
                 return AppCompatResources.getDrawable(context, R.drawable.ic_placeholder_song);
             default:
             case Unknown:
-                return new ColorDrawable(SurfaceColors.SURFACE_5.getColor(context));
+                TypedValue value = new TypedValue();
+                context.getTheme().resolveAttribute(R.attr.colorSurfaceContainerHighest, value, true);
+                return new ColorDrawable(value.data);
         }
     }
 

--- a/app/src/main/res/layout/item_placehoder_biography.xml
+++ b/app/src/main/res/layout/item_placehoder_biography.xml
@@ -20,7 +20,7 @@
             android:layout_marginTop="12dp"
             android:layout_marginEnd="8dp"
             android:layout_weight="9"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
 
         <ImageView
             android:layout_width="12dp"
@@ -29,7 +29,7 @@
             android:layout_marginTop="12dp"
             android:layout_marginEnd="8dp"
             android:layout_weight="1"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
     </LinearLayout>
 
     <ImageView
@@ -39,5 +39,5 @@
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="8dp"
-        android:background="?attr/colorSurface" />
+        android:background="?attr/colorSurfaceContainerHigh" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_placehoder_discovery.xml
+++ b/app/src/main/res/layout/item_placehoder_discovery.xml
@@ -20,7 +20,7 @@
             android:layout_marginTop="12dp"
             android:layout_marginEnd="8dp"
             android:layout_weight="9"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
 
         <ImageView
             android:layout_width="12dp"
@@ -29,7 +29,7 @@
             android:layout_marginTop="12dp"
             android:layout_marginEnd="8dp"
             android:layout_weight="1"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
     </LinearLayout>
 
     <ImageView
@@ -39,5 +39,5 @@
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="8dp"
-        android:background="?attr/colorSurface" />
+        android:background="?attr/colorSurfaceContainerHigh" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_placeholder_album.xml
+++ b/app/src/main/res/layout/item_placeholder_album.xml
@@ -20,7 +20,7 @@
             android:layout_marginTop="12dp"
             android:layout_marginEnd="8dp"
             android:layout_weight="8"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
 
         <ImageView
             android:layout_width="12dp"
@@ -29,7 +29,7 @@
             android:layout_marginTop="22dp"
             android:layout_marginEnd="8dp"
             android:layout_weight="2"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
     </LinearLayout>
 
     <LinearLayout
@@ -53,19 +53,19 @@
                 android:layout_width="172dp"
                 android:layout_height="172dp"
                 android:layout_gravity="center"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
 
             <ImageView
                 android:layout_width="124dp"
                 android:layout_height="14dp"
                 android:layout_marginTop="8dp"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
 
             <ImageView
                 android:layout_width="112dp"
                 android:layout_height="12dp"
                 android:layout_marginTop="4dp"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
         </LinearLayout>
 
         <LinearLayout
@@ -78,19 +78,19 @@
                 android:layout_width="172dp"
                 android:layout_height="172dp"
                 android:layout_gravity="center"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
 
             <ImageView
                 android:layout_width="124dp"
                 android:layout_height="14dp"
                 android:layout_marginTop="8dp"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
 
             <ImageView
                 android:layout_width="112dp"
                 android:layout_height="12dp"
                 android:layout_marginTop="4dp"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
         </LinearLayout>
 
         <LinearLayout
@@ -102,19 +102,19 @@
                 android:layout_width="172dp"
                 android:layout_height="172dp"
                 android:layout_gravity="center"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
 
             <ImageView
                 android:layout_width="124dp"
                 android:layout_height="14dp"
                 android:layout_marginTop="8dp"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
 
             <ImageView
                 android:layout_width="112dp"
                 android:layout_height="12dp"
                 android:layout_marginTop="4dp"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
         </LinearLayout>
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/item_placeholder_genre.xml
+++ b/app/src/main/res/layout/item_placeholder_genre.xml
@@ -12,7 +12,7 @@
         android:layout_marginTop="20dp"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="8dp"
-        android:background="?attr/colorSurface" />
+        android:background="?attr/colorSurfaceContainerHigh" />
 
     <LinearLayout
         android:layout_width="wrap_content"
@@ -27,7 +27,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
 
         <ImageView
             android:layout_width="196dp"
@@ -35,7 +35,7 @@
             android:layout_gravity="center"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
 
         <ImageView
             android:layout_width="196dp"
@@ -43,7 +43,7 @@
             android:layout_gravity="center"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
     </LinearLayout>
 
     <LinearLayout
@@ -58,7 +58,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
 
         <ImageView
             android:layout_width="196dp"
@@ -66,7 +66,7 @@
             android:layout_gravity="center"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
 
         <ImageView
             android:layout_width="196dp"
@@ -74,7 +74,7 @@
             android:layout_gravity="center"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
     </LinearLayout>
 
     <LinearLayout
@@ -89,7 +89,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
 
         <ImageView
             android:layout_width="196dp"
@@ -97,7 +97,7 @@
             android:layout_gravity="center"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
 
         <ImageView
             android:layout_width="196dp"
@@ -105,6 +105,6 @@
             android:layout_gravity="center"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="4dp"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/item_placeholder_horizontal.xml
+++ b/app/src/main/res/layout/item_placeholder_horizontal.xml
@@ -21,7 +21,7 @@
             android:layout_marginTop="12dp"
             android:layout_marginEnd="8dp"
             android:layout_weight="8"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
 
         <ImageView
             android:layout_width="12dp"
@@ -30,7 +30,7 @@
             android:layout_marginTop="22dp"
             android:layout_marginEnd="8dp"
             android:layout_weight="2"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
     </LinearLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -46,7 +46,7 @@
             android:layout_height="52dp"
             android:layout_gravity="center"
             android:layout_margin="2dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -58,7 +58,7 @@
             android:layout_marginStart="12dp"
             android:layout_marginTop="10dp"
             android:layout_marginEnd="12dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintStart_toEndOf="@+id/album_cover_placeholder_1"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -68,7 +68,7 @@
             android:layout_marginStart="12dp"
             android:layout_marginTop="4dp"
             android:layout_marginEnd="16dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintStart_toEndOf="@+id/album_cover_placeholder_1"
             app:layout_constraintTop_toBottomOf="@+id/album_title_placeholder_1" />
 
@@ -77,7 +77,7 @@
             android:layout_height="18dp"
             android:layout_marginStart="12dp"
             android:layout_marginEnd="12dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             android:gravity="center_vertical"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -98,7 +98,7 @@
             android:layout_height="52dp"
             android:layout_gravity="center"
             android:layout_margin="2dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -110,7 +110,7 @@
             android:layout_marginStart="12dp"
             android:layout_marginTop="10dp"
             android:layout_marginEnd="12dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintStart_toEndOf="@+id/album_cover_placeholder_2"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -120,7 +120,7 @@
             android:layout_marginStart="12dp"
             android:layout_marginTop="4dp"
             android:layout_marginEnd="16dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintStart_toEndOf="@+id/album_cover_placeholder_2"
             app:layout_constraintTop_toBottomOf="@+id/album_title_placeholder_2" />
 
@@ -129,7 +129,7 @@
             android:layout_height="18dp"
             android:layout_marginStart="12dp"
             android:layout_marginEnd="12dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             android:gravity="center_vertical"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -150,7 +150,7 @@
             android:layout_height="52dp"
             android:layout_gravity="center"
             android:layout_margin="2dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -162,7 +162,7 @@
             android:layout_marginStart="12dp"
             android:layout_marginTop="10dp"
             android:layout_marginEnd="12dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintStart_toEndOf="@+id/album_cover_placeholder_3"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -172,7 +172,7 @@
             android:layout_marginStart="12dp"
             android:layout_marginTop="4dp"
             android:layout_marginEnd="16dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintStart_toEndOf="@+id/album_cover_placeholder_3"
             app:layout_constraintTop_toBottomOf="@+id/album_title_placeholder_3" />
 
@@ -181,7 +181,7 @@
             android:layout_height="18dp"
             android:layout_marginStart="12dp"
             android:layout_marginEnd="12dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             android:gravity="center_vertical"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -202,7 +202,7 @@
             android:layout_height="52dp"
             android:layout_gravity="center"
             android:layout_margin="2dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -214,7 +214,7 @@
             android:layout_marginStart="12dp"
             android:layout_marginTop="10dp"
             android:layout_marginEnd="12dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintStart_toEndOf="@+id/album_cover_placeholder_4"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -224,7 +224,7 @@
             android:layout_marginStart="12dp"
             android:layout_marginTop="4dp"
             android:layout_marginEnd="16dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintStart_toEndOf="@+id/album_cover_placeholder_4"
             app:layout_constraintTop_toBottomOf="@+id/album_title_placeholder_4" />
 
@@ -233,7 +233,7 @@
             android:layout_height="18dp"
             android:layout_marginStart="12dp"
             android:layout_marginEnd="12dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             android:gravity="center_vertical"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -254,7 +254,7 @@
             android:layout_height="52dp"
             android:layout_gravity="center"
             android:layout_margin="2dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -266,7 +266,7 @@
             android:layout_marginStart="12dp"
             android:layout_marginTop="10dp"
             android:layout_marginEnd="12dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintStart_toEndOf="@+id/album_cover_placeholder_5"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -276,7 +276,7 @@
             android:layout_marginStart="12dp"
             android:layout_marginTop="4dp"
             android:layout_marginEnd="16dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             app:layout_constraintStart_toEndOf="@+id/album_cover_placeholder_5"
             app:layout_constraintTop_toBottomOf="@+id/album_title_placeholder_5" />
 
@@ -285,7 +285,7 @@
             android:layout_height="18dp"
             android:layout_marginStart="12dp"
             android:layout_marginEnd="12dp"
-            android:background="?attr/colorSurface"
+            android:background="?attr/colorSurfaceContainerHigh"
             android:gravity="center_vertical"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_placeholder_large_album.xml
+++ b/app/src/main/res/layout/item_placeholder_large_album.xml
@@ -20,7 +20,7 @@
             android:layout_marginTop="12dp"
             android:layout_marginEnd="8dp"
             android:layout_weight="8"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
 
         <ImageView
             android:layout_width="12dp"
@@ -29,7 +29,7 @@
             android:layout_marginTop="22dp"
             android:layout_marginEnd="8dp"
             android:layout_weight="2"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
     </LinearLayout>
 
     <LinearLayout
@@ -53,19 +53,19 @@
                 android:layout_width="172dp"
                 android:layout_height="172dp"
                 android:layout_gravity="center"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
 
             <ImageView
                 android:layout_width="124dp"
                 android:layout_height="14dp"
                 android:layout_marginTop="8dp"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
 
             <ImageView
                 android:layout_width="112dp"
                 android:layout_height="12dp"
                 android:layout_marginTop="4dp"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
         </LinearLayout>
 
         <LinearLayout
@@ -78,19 +78,19 @@
                 android:layout_width="172dp"
                 android:layout_height="172dp"
                 android:layout_gravity="center"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
 
             <ImageView
                 android:layout_width="124dp"
                 android:layout_height="14dp"
                 android:layout_marginTop="8dp"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
 
             <ImageView
                 android:layout_width="112dp"
                 android:layout_height="12dp"
                 android:layout_marginTop="4dp"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
         </LinearLayout>
 
         <LinearLayout
@@ -102,19 +102,19 @@
                 android:layout_width="172dp"
                 android:layout_height="172dp"
                 android:layout_gravity="center"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
 
             <ImageView
                 android:layout_width="124dp"
                 android:layout_height="14dp"
                 android:layout_marginTop="8dp"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
 
             <ImageView
                 android:layout_width="112dp"
                 android:layout_height="12dp"
                 android:layout_marginTop="4dp"
-                android:background="?attr/colorSurface" />
+                android:background="?attr/colorSurfaceContainerHigh" />
         </LinearLayout>
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/item_placeholder_year.xml
+++ b/app/src/main/res/layout/item_placeholder_year.xml
@@ -12,7 +12,7 @@
         android:layout_marginTop="20dp"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="8dp"
-        android:background="?attr/colorSurface" />
+        android:background="?attr/colorSurfaceContainerHigh" />
 
     <LinearLayout
         android:layout_width="wrap_content"
@@ -27,7 +27,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginEnd="12dp"
             android:layout_marginBottom="8dp"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
 
         <ImageView
             android:layout_width="172dp"
@@ -35,7 +35,7 @@
             android:layout_gravity="center"
             android:layout_marginEnd="12dp"
             android:layout_marginBottom="8dp"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
 
         <ImageView
             android:layout_width="172dp"
@@ -43,6 +43,6 @@
             android:layout_gravity="center"
             android:layout_marginEnd="12dp"
             android:layout_marginBottom="8dp"
-            android:background="?attr/colorSurface" />
+            android:background="?attr/colorSurfaceContainerHigh" />
     </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Hey! I noticed that the placeholders were not showing in the app, because they were colored using `?attr/colorSurface`, which blended in perfectly with the background. I fixed it using `?attr/colorSurfaceContainerHigh` instead, the same color I used for cover placeholders. I also applied that color to the blank squares that show before the covers load.

There's something else I noticed, by the way. When fetching things such as playlists, which are initially null, the client first returns an empty array twice, before returning the actual playlists. This results in the placeholders not showing (View.GONE) before the playlists load.

```java
libraryViewModel.getPlaylistSample(getViewLifecycleOwner()).observe(getViewLifecycleOwner(), playlists -> {
    Log.d("LibraryFragment", (playlists != null) ? playlists.toString() : "null");
    // ...
});
```

Here are the logs. Please check the timestamps.

```
2023-09-08 11:16:09.588  null
2023-09-08 11:16:09.610  []
2023-09-08 11:16:09.858  []
2023-09-08 11:16:21.543  [com.cappielloantonio.tempo.subsonic.models.Playlist@8d788d, com.cappielloantonio.tempo.subsonic.models.Playlist@1057a42, com.cappielloantonio.tempo.subsonic.models.Playlist@ba15a53, com.cappielloantonio.tempo.subsonic.models.Playlist@c6aef90, com.cappielloantonio.tempo.subsonic.models.Playlist@7e61089]
```
