### PR TITLE
feat: add notification groups

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/DownloaderService.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/DownloaderService.java
@@ -52,16 +52,38 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
 
     private static final class TerminalStateNotificationHelper implements DownloadManager.Listener {
         private static final String TAG = "TerminalStateNotificatinHelper";
+        private static final String SUCCESSFUL_DOWNLOAD_GROUP = "com.cappielloantonio.tempo.SuccessfulDownload";
+        private static final String FAILED_DOWNLOAD_GROUP = "com.cappielloantonio.tempo.FailedDownload";
+
 
         private final Context context;
         private final DownloadNotificationHelper notificationHelper;
-
         private int nextNotificationId;
+        private final Notification successfulDownloadGroupNotification;
+        private final Notification failedDownloadGroupNotification;
+        private final int successfulDownloadGroupNotificationId;
+        private final int failedDownloadGroupNotificationId;
 
         public TerminalStateNotificationHelper(Context context, DownloadNotificationHelper notificationHelper, int firstNotificationId) {
             this.context = context.getApplicationContext();
             this.notificationHelper = notificationHelper;
             nextNotificationId = firstNotificationId;
+
+            successfulDownloadGroupNotification = DownloadUtil.buildGroupSummaryNotification(
+                    this.context,
+                    DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID,
+                    SUCCESSFUL_DOWNLOAD_GROUP,
+                    R.drawable.ic_check_circle,
+                    "Downloads completed");
+            failedDownloadGroupNotification = DownloadUtil.buildGroupSummaryNotification(
+                    this.context,
+                    DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID,
+                    FAILED_DOWNLOAD_GROUP,
+                    R.drawable.ic_check_circle,
+                    "Downloads failed");
+
+            successfulDownloadGroupNotificationId = nextNotificationId++;
+            failedDownloadGroupNotificationId = nextNotificationId++;
         }
 
         @Override
@@ -70,9 +92,13 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
 
             if (download.state == Download.STATE_COMPLETED) {
                 notification = notificationHelper.buildDownloadCompletedNotification(context, R.drawable.ic_check_circle, null, DownloaderManager.getDownloadNotificationMessage(download.request.id));
+                notification = Notification.Builder.recoverBuilder(context, notification).setGroup(SUCCESSFUL_DOWNLOAD_GROUP).build();
+                NotificationUtil.setNotification(this.context, successfulDownloadGroupNotificationId, successfulDownloadGroupNotification);
                 DownloaderManager.updateDatabase(download.request.id);
             } else if (download.state == Download.STATE_FAILED) {
                 notification = notificationHelper.buildDownloadFailedNotification(context, R.drawable.ic_error, null, DownloaderManager.getDownloadNotificationMessage(download.request.id));
+                notification = Notification.Builder.recoverBuilder(context, notification).setGroup(FAILED_DOWNLOAD_GROUP).build();
+                NotificationUtil.setNotification(this.context, failedDownloadGroupNotificationId, failedDownloadGroupNotification);
             } else {
                 return;
             }

--- a/app/src/main/java/com/cappielloantonio/tempo/util/DownloadUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/DownloadUtil.java
@@ -1,7 +1,9 @@
 package com.cappielloantonio.tempo.util;
 
+import android.app.Notification;
 import android.content.Context;
 
+import androidx.core.app.NotificationCompat;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.database.DatabaseProvider;
 import androidx.media3.database.StandaloneDatabaseProvider;
@@ -182,4 +184,14 @@ public final class DownloadUtil {
 
         return files;
     }
+
+    public static Notification buildGroupSummaryNotification(Context context, String channelId, String groupId, int icon, String title) {
+        return new NotificationCompat.Builder(context, channelId)
+                .setContentTitle(title)
+                .setSmallIcon(icon)
+                .setGroup(groupId)
+                .setGroupSummary(true)
+                .build();
+    }
+
 }


### PR DESCRIPTION
resolves #73 
resolves #52

Adds notification groups to download completed and download failed notifications. Should work properly with everything >= 24 api level, which I believe is the minimum supported anyway.