### PR TITLE
Draft: feat: Add Shuffle All button to Downloaded section

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/DownloadHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/DownloadHorizontalAdapter.java
@@ -90,6 +90,10 @@ public class DownloadHorizontalAdapter extends RecyclerView.Adapter<DownloadHori
         return grouped.get(id);
     }
 
+    public List<Child> getItems() {
+        return new ArrayList<>(songs);
+    }
+
     @Override
     public int getItemViewType(int position) {
         return position;

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/DownloadFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/DownloadFragment.java
@@ -32,7 +32,10 @@ import com.cappielloantonio.tempo.util.Preferences;
 import com.cappielloantonio.tempo.viewmodel.DownloadViewModel;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -75,6 +78,7 @@ public class DownloadFragment extends Fragment implements ClickCallback {
         super.onStart();
 
         initializeMediaBrowser();
+        bindMediaController();
         activity.setBottomNavigationBarVisibility(true);
         activity.setBottomSheetVisibility(true);
     }
@@ -110,6 +114,7 @@ public class DownloadFragment extends Fragment implements ClickCallback {
                     if (bind != null) {
                         bind.emptyDownloadLayout.setVisibility(View.VISIBLE);
                         bind.fragmentDownloadNestedScrollView.setVisibility(View.GONE);
+                        bind.downloadedShuffleAllFab.setVisibility(View.GONE);
 
                         bind.downloadDownloadedPlaceholder.placeholder.setVisibility(View.VISIBLE);
                         bind.downloadDownloadedSector.setVisibility(View.GONE);
@@ -120,6 +125,7 @@ public class DownloadFragment extends Fragment implements ClickCallback {
                     if (bind != null) {
                         bind.emptyDownloadLayout.setVisibility(View.GONE);
                         bind.fragmentDownloadNestedScrollView.setVisibility(View.VISIBLE);
+                        bind.downloadedShuffleAllFab.setVisibility(View.VISIBLE);
 
                         bind.downloadDownloadedPlaceholder.placeholder.setVisibility(View.GONE);
                         bind.downloadDownloadedSector.setVisibility(View.VISIBLE);
@@ -136,6 +142,25 @@ public class DownloadFragment extends Fragment implements ClickCallback {
 
         bind.downloadedGroupByImageView.setOnClickListener(view -> showPopupMenu(view, R.menu.download_popup_menu));
         bind.downloadedGoBackImageView.setOnClickListener(view -> downloadViewModel.popViewStack());
+    }
+
+    private void bindMediaController() {
+        mediaBrowserListenableFuture.addListener(() -> {
+            try {
+                MediaBrowser mediaBrowser = mediaBrowserListenableFuture.get();
+                initShuffleButton(mediaBrowser);
+            } catch (Exception exception) {
+                exception.printStackTrace();
+            }
+        }, MoreExecutors.directExecutor());
+    }
+
+    private void initShuffleButton(MediaBrowser mediaBrowser) {
+        bind.downloadedShuffleAllFab.setOnClickListener(view -> {
+            List<Child> songs = downloadHorizontalAdapter.getItems();
+            Collections.shuffle(songs);
+            MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
+        });
     }
 
     private void finishDownloadView(List<Child> songs) {

--- a/app/src/main/res/layout/fragment_download.xml
+++ b/app/src/main/res/layout/fragment_download.xml
@@ -76,7 +76,6 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:text="@string/download_title_section"
-                android:layout_marginBottom="16dp"
                 app:layout_constraintEnd_toStartOf="@+id/downloaded_go_back_image_view"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -86,7 +85,6 @@
                 android:layout_width="24dp"
                 android:layout_height="24dp"
                 android:layout_marginHorizontal="12dp"
-                android:layout_gravity="center"
                 android:background="@drawable/ic_arrow_back"
                 app:layout_constraintBottom_toBottomOf="@+id/downloaded_text_view_refreshable"
                 app:layout_constraintEnd_toStartOf="@id/downloaded_group_by_image_view"
@@ -122,8 +120,16 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/downloaded_text_view_refreshable" />
-
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/downloaded_shuffle_all_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:translationY="-128dp"
+        app:srcCompat="@drawable/ic_shuffle" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
 


### PR DESCRIPTION
Added Shuffle All button that plays and shuffles all downloaded songs.

related issue: #132 

It seems that I suck at layouting, so I'd appreciate help with properly layouting the floating button, as it doesn't look good when no song is playing, and if it's lower it gets covered up by the currently playing song