### PR TITLE
fix: Fix issues with AlbumCatalogue

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/AlbumCatalogueAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/AlbumCatalogueAdapter.java
@@ -23,6 +23,8 @@ import java.util.List;
 
 public class AlbumCatalogueAdapter extends RecyclerView.Adapter<AlbumCatalogueAdapter.ViewHolder> implements Filterable {
     private final ClickCallback click;
+    private String currentFilter;
+
     private final Filter filtering = new Filter() {
         @Override
         protected FilterResults performFiltering(CharSequence constraint) {
@@ -32,6 +34,7 @@ public class AlbumCatalogueAdapter extends RecyclerView.Adapter<AlbumCatalogueAd
                 filteredList.addAll(albumsFull);
             } else {
                 String filterPattern = constraint.toString().toLowerCase().trim();
+                currentFilter = filterPattern;
 
                 for (AlbumID3 item : albumsFull) {
                     if (item.getName().toLowerCase().contains(filterPattern)) {
@@ -48,8 +51,7 @@ public class AlbumCatalogueAdapter extends RecyclerView.Adapter<AlbumCatalogueAd
 
         @Override
         protected void publishResults(CharSequence constraint, FilterResults results) {
-            albums.clear();
-            albums.addAll((List) results.values);
+            albums = (List) results.values;
             notifyDataSetChanged();
         }
     };
@@ -60,6 +62,8 @@ public class AlbumCatalogueAdapter extends RecyclerView.Adapter<AlbumCatalogueAd
     public AlbumCatalogueAdapter(ClickCallback click) {
         this.click = click;
         this.albums = Collections.emptyList();
+        this.albumsFull = Collections.emptyList();
+        this.currentFilter = "";
     }
 
     @NonNull
@@ -92,9 +96,8 @@ public class AlbumCatalogueAdapter extends RecyclerView.Adapter<AlbumCatalogueAd
     }
 
     public void setItems(List<AlbumID3> albums) {
-        this.albums = albums;
         this.albumsFull = new ArrayList<>(albums);
-        notifyDataSetChanged();
+        filtering.filter(currentFilter);
     }
 
     @Override

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumCatalogueFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumCatalogueFragment.java
@@ -53,6 +53,12 @@ public class AlbumCatalogueFragment extends Fragment implements ClickCallback {
     }
 
     @Override
+    public void onDestroy() {
+        super.onDestroy();
+        albumCatalogueViewModel.stopLoading();
+    }
+
+    @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         activity = (MainActivity) getActivity();
 
@@ -73,7 +79,7 @@ public class AlbumCatalogueFragment extends Fragment implements ClickCallback {
 
     private void initData() {
         albumCatalogueViewModel = new ViewModelProvider(requireActivity()).get(AlbumCatalogueViewModel.class);
-        albumCatalogueViewModel.loadAlbums(500);
+        albumCatalogueViewModel.loadAlbums();
     }
 
     private void initAppBar() {

--- a/app/src/main/java/com/cappielloantonio/tempo/viewmodel/AlbumCatalogueViewModel.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/viewmodel/AlbumCatalogueViewModel.java
@@ -36,7 +36,6 @@ public class AlbumCatalogueViewModel extends AndroidViewModel {
     public void loadAlbums() {
         page = 0;
         albumList.setValue(new ArrayList<>());
-        albumList.setValue(new ArrayList<>());
         status = Status.RUNNING;
         loadAlbums(500);
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/viewmodel/AlbumCatalogueViewModel.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/viewmodel/AlbumCatalogueViewModel.java
@@ -1,6 +1,7 @@
 package com.cappielloantonio.tempo.viewmodel;
 
 import android.app.Application;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
@@ -22,6 +23,7 @@ public class AlbumCatalogueViewModel extends AndroidViewModel {
     private final MutableLiveData<List<AlbumID3>> albumList = new MutableLiveData<>(new ArrayList<>());
 
     private int page = 0;
+    private Status status = Status.STOPPED;
 
     public AlbumCatalogueViewModel(@NonNull Application application) {
         super(application);
@@ -31,7 +33,19 @@ public class AlbumCatalogueViewModel extends AndroidViewModel {
         return albumList;
     }
 
-    public void loadAlbums(int size) {
+    public void loadAlbums() {
+        page = 0;
+        albumList.setValue(new ArrayList<>());
+        albumList.setValue(new ArrayList<>());
+        status = Status.RUNNING;
+        loadAlbums(500);
+    }
+
+    public void stopLoading() {
+        status = Status.STOPPED;
+    }
+
+    private void loadAlbums(int size) {
         retrieveAlbums(new MediaCallback() {
             @Override
             public void onError(Exception exception) {
@@ -39,9 +53,11 @@ public class AlbumCatalogueViewModel extends AndroidViewModel {
 
             @Override
             public void onLoadMedia(List<?> media) {
-                List<AlbumID3> liveAlbum = albumList.getValue();
+                if (status == Status.STOPPED) {
+                    return;
+                }
 
-                if (liveAlbum == null) liveAlbum = new ArrayList<>();
+                List<AlbumID3> liveAlbum = albumList.getValue();
 
                 liveAlbum.addAll((List<AlbumID3>) media);
                 albumList.setValue(liveAlbum);
@@ -72,5 +88,10 @@ public class AlbumCatalogueViewModel extends AndroidViewModel {
                         callback.onError(new Exception(t.getMessage()));
                     }
                 });
+    }
+
+    private enum Status {
+        RUNNING,
+        STOPPED
     }
 }


### PR DESCRIPTION
There are currently several issues with AlbumCatalogue implementation:
- Closing it and opening it while searching will not clear the filter
- It keeps loading data even after being closed
- When new data is fetched while searching, it just gets appended at the end instead of getting filtered.

This PR seeks to fix all of these issues.

It currently always fetches the AlbumList from server each time it is opened, this could however be easily changed to just cache the result of the first load. Let me know what you think.

Resolves #146 