### PR TITLE
Fix negative replay gain values

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/util/ReplayGainUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/ReplayGainUtil.java
@@ -102,7 +102,7 @@ public class ReplayGainUtil {
 
     private static Float parseReplayGainTag(Metadata.Entry entry) {
         try {
-            return Float.parseFloat(entry.toString().replaceAll("[^\\d.]", ""));
+            return Float.parseFloat(entry.toString().replaceAll("[^\\d.-]", ""));
         } catch (NumberFormatException exception) {
             return 0f;
         }


### PR DESCRIPTION
This regular expression converts `-10.71` into `10.71` by ignoring `-`, making a track that is too loud even louder.

```
Format                                   : FLAC
Format/Info                              : Free Lossless Audio Codec
Duration                                 : 3 min 11 s
Bit rate mode                            : Variable
Bit rate                                 : 3 417 kb/s
Channel(s)                               : 2 channels
Channel layout                           : L R
Sampling rate                            : 96.0 kHz
Bit depth                                : 24 bits
Compression mode                         : Lossless
Replay gain                              : -10.71 dB
Replay gain peak                         : 0.785145
Stream size                              : 78.0 MiB (100%)
Writing library                          : Lavf58.76.100
MD5 of the unencoded content             : 144B59C4B27E5F30DC97A6385AD42156
```