### PR TITLE
[WIP] Cache streaming contents

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsFragment.java
@@ -30,6 +30,7 @@ import com.cappielloantonio.tempo.ui.activity.MainActivity;
 import com.cappielloantonio.tempo.ui.dialog.DeleteDownloadStorageDialog;
 import com.cappielloantonio.tempo.ui.dialog.DownloadStorageDialog;
 import com.cappielloantonio.tempo.ui.dialog.StarredSyncDialog;
+import com.cappielloantonio.tempo.util.DownloadUtil;
 import com.cappielloantonio.tempo.util.Preferences;
 import com.cappielloantonio.tempo.util.UIUtil;
 import com.cappielloantonio.tempo.viewmodel.SettingViewModel;
@@ -112,6 +113,22 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                         ThemeHelper.applyTheme(themeOption);
                         return true;
                     });
+        }
+
+        ListPreference streamingCachePreference = findPreference("streaming_cache_size");
+        if (streamingCachePreference != null) {
+            streamingCachePreference.setSummaryProvider(new Preference.SummaryProvider<ListPreference>() {
+                @Nullable
+                @Override
+                public CharSequence provideSummary(@NonNull ListPreference preference) {
+                    CharSequence entry = preference.getEntry();
+                    if (entry == null) {
+                        return null;
+                    }
+                    long currentSizeMb = DownloadUtil.getStreamingCacheSize(requireActivity()) / (1024 * 1024);
+                    return entry + "\nCurrently in use: " +  + currentSizeMb + " MiB\nRestarting is required if changed.";
+                }
+            });
         }
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -22,6 +22,7 @@ object Preferences {
     private const val PLAYBACK_SPEED = "playback_speed"
     private const val SKIP_SILENCE = "skip_silence"
     private const val IMAGE_CACHE_SIZE = "image_cache_size"
+    private const val STREAMING_CACHE_SIZE = "streaming_cache_size"
     private const val IMAGE_SIZE = "image_size"
     private const val MAX_BITRATE_WIFI = "max_bitrate_wifi"
     private const val MAX_BITRATE_MOBILE = "max_bitrate_mobile"
@@ -185,6 +186,14 @@ object Preferences {
     @JvmStatic
     fun getImageSize(): Int {
         return App.getInstance().preferences.getString(IMAGE_SIZE, "-1")!!.toInt()
+    }
+
+    /**
+     * Size of streaming cache in MiB.
+     */
+    @JvmStatic
+    fun getStreamingCacheSize(): Long {
+        return App.getInstance().preferences.getString(STREAMING_CACHE_SIZE, "256")!!.toLong()
     }
 
     @JvmStatic

--- a/app/src/main/java/com/cappielloantonio/tempo/util/StreamingCacheDataSource.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/StreamingCacheDataSource.kt
@@ -1,0 +1,61 @@
+package com.cappielloantonio.tempo.util
+
+import android.net.Uri
+import android.util.Log
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.TransferListener
+import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.datasource.cache.ContentMetadata
+
+@UnstableApi
+class StreamingCacheDataSource private constructor(
+    private val cacheDataSource: CacheDataSource,
+): DataSource {
+    private val TAG = "StreamingCacheDataSource"
+
+    private var currentDataSpec: DataSpec? = null
+
+    class Factory(private val cacheDatasourceFactory: CacheDataSource.Factory): DataSource.Factory {
+        override fun createDataSource(): DataSource {
+            return StreamingCacheDataSource(cacheDatasourceFactory.createDataSource())
+        }
+    }
+
+    override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+        return cacheDataSource.read(buffer, offset, length)
+    }
+
+    override fun addTransferListener(transferListener: TransferListener) {
+        return cacheDataSource.addTransferListener(transferListener)
+    }
+
+    override fun open(dataSpec: DataSpec): Long {
+        val ret = cacheDataSource.open(dataSpec)
+        currentDataSpec = dataSpec
+        Log.d(TAG, "Opened $currentDataSpec")
+        return ret
+    }
+
+    override fun getUri(): Uri? {
+        return cacheDataSource.uri
+    }
+
+    override fun close() {
+        cacheDataSource.close()
+        Log.d(TAG, "Closed $currentDataSpec")
+        val dataSpec = currentDataSpec
+        if (dataSpec != null) {
+            val cacheKey = cacheDataSource.cacheKeyFactory.buildCacheKey(dataSpec)
+            val contentLength = ContentMetadata.getContentLength(cacheDataSource.cache.getContentMetadata(cacheKey));
+            if (contentLength == C.LENGTH_UNSET.toLong()) {
+                Log.d(TAG, "Removing partial cache for $cacheKey")
+                cacheDataSource.cache.removeResource(cacheKey)
+            } else {
+                Log.d(TAG, "Key $cacheKey has been fully cached")
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -32,6 +32,21 @@
         <item>300</item>
     </string-array>
 
+    <string-array name="streaming_cache_size_titles">
+        <item>Disabled</item>
+        <item>128 MiB</item>
+        <item>256 MiB</item>
+        <item>512 MiB</item>
+        <item>1024 MiB</item>
+    </string-array>
+    <string-array name="streaming_cache_size_values">
+        <item>0</item>
+        <item>128</item>
+        <item>256</item>
+        <item>512</item>
+        <item>1024</item>
+    </string-array>
+
     <string-array name="max_bitrate_wifi_list_titles">
         <item>Original</item>
         <item>32 kbps</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -367,4 +367,5 @@
     <string name="undraw_page">unDraw</string>
     <string name="undraw_thanks">A special thanks goes to unDraw without whose illustrations we could not have made this application more beautiful.</string>
     <string name="undraw_url">https://undraw.co/</string>
+    <string name="settings_streaming_cache_size">Size of streaming cache</string>
 </resources>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -95,6 +95,14 @@
             app:title="@string/settings_image_size"
             app:useSimpleSummaryProvider="true" />
 
+        <ListPreference
+            app:defaultValue="256"
+            app:dialogTitle="@string/settings_streaming_cache_size"
+            app:entries="@array/streaming_cache_size_titles"
+            app:entryValues="@array/streaming_cache_size_values"
+            app:key="streaming_cache_size"
+            app:title="@string/settings_streaming_cache_size" />
+
         <SwitchPreference
             android:title="@string/settings_wifi_only_title"
             android:defaultValue="false"


### PR DESCRIPTION
Try to cache streaming contents (including transcoding responses), there are still rough edges to finish.

The current implementation removes cached data if the response stream is never read to EOF and does not have a `Content-Length` (this covers both raw files with a known length and transcoded responses). Estimating content length might mess with this functionality, more testing is required.