### PR TITLE
Fix: App crashes on second open when local address empty

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -174,7 +174,7 @@ object Preferences {
 
     @JvmStatic
     fun isInUseServerAddressLocal(): Boolean {
-        return getInUseServerAddress() == getLocalAddress()
+        return getInUseServerAddress() == getLocalAddress() && !getLocalAddress().isNullOrEmpty()
     }
 
     @JvmStatic
@@ -187,7 +187,7 @@ object Preferences {
     fun isServerSwitchable(): Boolean {
         return App.getInstance().preferences.getLong(
                 NEXT_SERVER_SWITCH, 0
-        ) + 15000 < System.currentTimeMillis()
+        ) + 15000 < System.currentTimeMillis() && !getServer().isNullOrEmpty() && !getLocalAddress().isNullOrEmpty()
     }
 
     @JvmStatic


### PR DESCRIPTION
The app crashes on startup after following these steps:

- Install the app
- Add a server, leave the local address empty
- Login
- Close the app
- Reopen the app

The issue was that the app tried to switch to the local address, which is empty.

Related commit: f6b176a357767725a8078bd5076eab01f84faa16