### PR TITLE
Support non square cover art

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/glide/CustomGlideRequest.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/glide/CustomGlideRequest.java
@@ -132,5 +132,9 @@ public class CustomGlideRequest {
                     .load(item)
                     .transition(DrawableTransitionOptions.withCrossFade());
         }
+
+        public RequestBuilder<Drawable> build(boolean fitCenter) {
+            return fitCenter ? build().optionalFitCenter() : build();
+        }
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/AlbumAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/AlbumAdapter.java
@@ -43,7 +43,7 @@ public class AlbumAdapter extends RecyclerView.Adapter<AlbumAdapter.ViewHolder> 
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), album.getCoverArtId(), CustomGlideRequest.ResourceType.Album)
-                .build()
+                .build(true)
                 .into(holder.item.albumCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/AlbumArtistPageOrSimilarAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/AlbumArtistPageOrSimilarAdapter.java
@@ -43,7 +43,7 @@ public class AlbumArtistPageOrSimilarAdapter extends RecyclerView.Adapter<AlbumA
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), album.getCoverArtId(), CustomGlideRequest.ResourceType.Album)
-                .build()
+                .build(true)
                 .into(holder.item.artistPageAlbumCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/AlbumCatalogueAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/AlbumCatalogueAdapter.java
@@ -86,7 +86,7 @@ public class AlbumCatalogueAdapter extends RecyclerView.Adapter<AlbumCatalogueAd
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), album.getCoverArtId(), CustomGlideRequest.ResourceType.Album)
-                .build()
+                .build(true)
                 .into(holder.item.albumCatalogueCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/AlbumHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/AlbumHorizontalAdapter.java
@@ -45,7 +45,7 @@ public class AlbumHorizontalAdapter extends RecyclerView.Adapter<AlbumHorizontal
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), album.getCoverArtId(), CustomGlideRequest.ResourceType.Album)
-                .build()
+                .build(true)
                 .into(holder.item.albumCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistAdapter.java
@@ -48,7 +48,7 @@ public class ArtistAdapter extends RecyclerView.Adapter<ArtistAdapter.ViewHolder
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), artist.getCoverArtId(), CustomGlideRequest.ResourceType.Artist)
-                .build()
+                .build(true)
                 .into(holder.item.artistCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistCatalogueAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistCatalogueAdapter.java
@@ -78,7 +78,7 @@ public class ArtistCatalogueAdapter extends RecyclerView.Adapter<ArtistCatalogue
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), artist.getCoverArtId(), CustomGlideRequest.ResourceType.Artist)
-                .build()
+                .build(true)
                 .into(holder.item.artistCatalogueCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistHorizontalAdapter.java
@@ -49,7 +49,7 @@ public class ArtistHorizontalAdapter extends RecyclerView.Adapter<ArtistHorizont
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), artist.getCoverArtId(), CustomGlideRequest.ResourceType.Artist)
-                .build()
+                .build(true)
                 .into(holder.item.artistCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistSimilarAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistSimilarAdapter.java
@@ -42,7 +42,7 @@ public class ArtistSimilarAdapter extends RecyclerView.Adapter<ArtistSimilarAdap
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), artist.getCoverArtId(), CustomGlideRequest.ResourceType.Artist)
-                .build()
+                .build(true)
                 .into(holder.item.similarArtistCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/DownloadHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/DownloadHorizontalAdapter.java
@@ -199,7 +199,7 @@ public class DownloadHorizontalAdapter extends RecyclerView.Adapter<DownloadHori
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), song.getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                .build()
+                .build(true)
                 .into(holder.item.itemCoverImageView);
 
         holder.item.itemCoverImageView.setVisibility(View.VISIBLE);
@@ -222,7 +222,7 @@ public class DownloadHorizontalAdapter extends RecyclerView.Adapter<DownloadHori
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), song.getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                .build()
+                .build(true)
                 .into(holder.item.itemCoverImageView);
 
         holder.item.itemCoverImageView.setVisibility(View.VISIBLE);
@@ -244,7 +244,7 @@ public class DownloadHorizontalAdapter extends RecyclerView.Adapter<DownloadHori
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), song.getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                .build()
+                .build(true)
                 .into(holder.item.itemCoverImageView);
 
         holder.item.itemCoverImageView.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/GridTrackAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/GridTrackAdapter.java
@@ -40,7 +40,7 @@ public class GridTrackAdapter extends RecyclerView.Adapter<GridTrackAdapter.View
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), item.getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                .build()
+                .build(true)
                 .into(holder.item.trackCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/InternetRadioStationAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/InternetRadioStationAdapter.java
@@ -44,7 +44,7 @@ public class InternetRadioStationAdapter extends RecyclerView.Adapter<InternetRa
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), internetRadioStation.getStreamUrl(), CustomGlideRequest.ResourceType.Radio)
-                .build()
+                .build(true)
                 .into(holder.item.internetRadioStationCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/MusicDirectoryAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/MusicDirectoryAdapter.java
@@ -49,7 +49,7 @@ public class MusicDirectoryAdapter extends RecyclerView.Adapter<MusicDirectoryAd
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), child.getCoverArtId(), type)
-                .build()
+                .build(true)
                 .into(holder.item.musicDirectoryCoverImageView);
 
         holder.item.musicDirectoryMoreButton.setVisibility(child.isDir() ? View.VISIBLE : View.INVISIBLE);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/MusicIndexAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/MusicIndexAdapter.java
@@ -45,7 +45,7 @@ public class MusicIndexAdapter extends RecyclerView.Adapter<MusicIndexAdapter.Vi
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), artist.getName(), CustomGlideRequest.ResourceType.Directory)
-                .build()
+                .build(true)
                 .into(holder.item.musicIndexCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PlayerSongQueueAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PlayerSongQueueAdapter.java
@@ -60,7 +60,7 @@ public class PlayerSongQueueAdapter extends RecyclerView.Adapter<PlayerSongQueue
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), song.getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                .build()
+                .build(true)
                 .into(holder.item.queueSongCoverImageView);
 
         MediaManager.getCurrentIndex(mediaBrowserListenableFuture, new MediaIndexCallback() {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PlaylistDialogSongHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PlaylistDialogSongHorizontalAdapter.java
@@ -38,7 +38,7 @@ public class PlaylistDialogSongHorizontalAdapter extends RecyclerView.Adapter<Pl
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), song.getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                .build()
+                .build(true)
                 .into(holder.item.playlistDialogSongCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PlaylistHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PlaylistHorizontalAdapter.java
@@ -80,7 +80,7 @@ public class PlaylistHorizontalAdapter extends RecyclerView.Adapter<PlaylistHori
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), playlist.getCoverArtId(), CustomGlideRequest.ResourceType.Playlist)
-                .build()
+                .build(true)
                 .into(holder.item.playlistCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PodcastChannelCatalogueAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PodcastChannelCatalogueAdapter.java
@@ -76,7 +76,7 @@ public class PodcastChannelCatalogueAdapter extends RecyclerView.Adapter<Podcast
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), podcastChannel.getCoverArtId(), CustomGlideRequest.ResourceType.Podcast)
-                .build()
+                .build(true)
                 .into(holder.item.podcastChannelCatalogueCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PodcastChannelHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PodcastChannelHorizontalAdapter.java
@@ -43,7 +43,7 @@ public class PodcastChannelHorizontalAdapter extends RecyclerView.Adapter<Podcas
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), podcastChannel.getCoverArtId(), CustomGlideRequest.ResourceType.Podcast)
-                .build()
+                .build(true)
                 .into(holder.item.podcastChannelCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PodcastEpisodeAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PodcastEpisodeAdapter.java
@@ -52,7 +52,7 @@ public class PodcastEpisodeAdapter extends RecyclerView.Adapter<PodcastEpisodeAd
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), podcastEpisode.getCoverArtId(), CustomGlideRequest.ResourceType.Podcast)
-                .build()
+                .build(true)
                 .into(holder.item.podcastCoverImageView);
 
         holder.item.podcastPlayButton.setEnabled(podcastEpisode.getStatus().equals("completed"));

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ShareHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ShareHorizontalAdapter.java
@@ -45,7 +45,7 @@ public class ShareHorizontalAdapter extends RecyclerView.Adapter<ShareHorizontal
 
         if (share.getEntries() != null && !share.getEntries().isEmpty()) CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), share.getEntries().get(0).getCoverArtId(), CustomGlideRequest.ResourceType.Album)
-                .build()
+                .build(true)
                 .into(holder.item.shareCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SimilarTrackAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SimilarTrackAdapter.java
@@ -42,7 +42,7 @@ public class SimilarTrackAdapter extends RecyclerView.Adapter<SimilarTrackAdapte
 
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), song.getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                .build()
+                .build(true)
                 .into(holder.item.trackCoverImageView);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SongHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SongHorizontalAdapter.java
@@ -79,7 +79,7 @@ public class SongHorizontalAdapter extends RecyclerView.Adapter<SongHorizontalAd
 
         if (showCoverArt) CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), song.getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                .build()
+                .build(true)
                 .into(holder.item.songCoverImageView);
 
         holder.item.trackNumberTextView.setVisibility(showCoverArt ? View.INVISIBLE : View.VISIBLE);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/TrackInfoDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/TrackInfoDialog.java
@@ -56,7 +56,7 @@ public class TrackInfoDialog extends DialogFragment {
         if (mediaMetadata.extras != null) {
             CustomGlideRequest.Builder
                     .from(requireContext(), mediaMetadata.extras.getString("coverArtId", ""), CustomGlideRequest.ResourceType.Song)
-                    .build()
+                    .build(true)
                     .into(bind.trackCoverInfoImageView);
 
             bind.titleValueSector.setText(mediaMetadata.extras.getString("title", getString(R.string.label_placeholder)));

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
@@ -222,7 +222,7 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
     private void initBackCover() {
         albumPageViewModel.getAlbum().observe(getViewLifecycleOwner(), album -> {
             if (bind != null && album != null) {
-                CustomGlideRequest.Builder.from(requireContext(), album.getCoverArtId(), CustomGlideRequest.ResourceType.Album).build().into(bind.albumCoverImageView);
+                CustomGlideRequest.Builder.from(requireContext(), album.getCoverArtId(), CustomGlideRequest.ResourceType.Album).build(true).into(bind.albumCoverImageView);
             }
         });
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistPageFragment.java
@@ -129,7 +129,7 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
 
                 if (getContext() != null && bind != null) CustomGlideRequest.Builder
                         .from(requireContext(), artistPageViewModel.getArtist().getId(), CustomGlideRequest.ResourceType.Artist)
-                        .build()
+                        .build(true)
                         .into(bind.artistBackdropImageView);
 
                 if (bind != null) bind.bioTextView.setText(normalizedBio);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerBottomSheetFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerBottomSheetFragment.java
@@ -164,7 +164,7 @@ public class PlayerBottomSheetFragment extends Fragment {
 
             CustomGlideRequest.Builder
                     .from(requireContext(), mediaMetadata.extras.getString("coverArtId"), CustomGlideRequest.ResourceType.Song)
-                    .build()
+                    .build(true)
                     .into(bind.playerHeaderLayout.playerHeaderMediaCoverImage);
 
             bind.playerHeaderLayout.playerHeaderMediaTitleLabel.setVisibility(mediaMetadata.extras.getString("title") != null && !Objects.equals(mediaMetadata.extras.getString("title"), "") ? View.VISIBLE : View.GONE);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerCoverFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerCoverFragment.java
@@ -186,7 +186,7 @@ public class PlayerCoverFragment extends Fragment {
     private void setCover(MediaMetadata mediaMetadata) {
         CustomGlideRequest.Builder
                 .from(requireContext(), mediaMetadata.extras != null ? mediaMetadata.extras.getString("coverArtId") : null, CustomGlideRequest.ResourceType.Song)
-                .build()
+                .build(true)
                 .into(bind.nowPlayingSongCoverImageView);
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
@@ -182,28 +182,28 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
                 // Pic top-left
                 CustomGlideRequest.Builder
                         .from(requireContext(), !songs.isEmpty() ? songs.get(0).getCoverArtId() : playlistPageViewModel.getPlaylist().getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                        .build()
+                        .build(true)
                         .transform(new GranularRoundedCorners(CustomGlideRequest.CORNER_RADIUS, 0, 0, 0))
                         .into(bind.playlistCoverImageViewTopLeft);
 
                 // Pic top-right
                 CustomGlideRequest.Builder
                         .from(requireContext(), songs.size() > 1 ? songs.get(1).getCoverArtId() : playlistPageViewModel.getPlaylist().getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                        .build()
+                        .build(true)
                         .transform(new GranularRoundedCorners(0, CustomGlideRequest.CORNER_RADIUS, 0, 0))
                         .into(bind.playlistCoverImageViewTopRight);
 
                 // Pic bottom-left
                 CustomGlideRequest.Builder
                         .from(requireContext(), songs.size() > 2 ? songs.get(2).getCoverArtId() : playlistPageViewModel.getPlaylist().getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                        .build()
+                        .build(true)
                         .transform(new GranularRoundedCorners(0, 0, 0, CustomGlideRequest.CORNER_RADIUS))
                         .into(bind.playlistCoverImageViewBottomLeft);
 
                 // Pic bottom-right
                 CustomGlideRequest.Builder
                         .from(requireContext(), songs.size() > 3 ? songs.get(3).getCoverArtId() : playlistPageViewModel.getPlaylist().getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                        .build()
+                        .build(true)
                         .transform(new GranularRoundedCorners(0, 0, CustomGlideRequest.CORNER_RADIUS, 0))
                         .into(bind.playlistCoverImageViewBottomRight);
             }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/AlbumBottomSheetDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/AlbumBottomSheetDialog.java
@@ -88,7 +88,7 @@ public class AlbumBottomSheetDialog extends BottomSheetDialogFragment implements
         ImageView coverAlbum = view.findViewById(R.id.album_cover_image_view);
         CustomGlideRequest.Builder
                 .from(requireContext(), albumBottomSheetViewModel.getAlbum().getCoverArtId(), CustomGlideRequest.ResourceType.Album)
-                .build()
+                .build(true)
                 .into(coverAlbum);
 
         TextView titleAlbum = view.findViewById(R.id.album_title_text_view);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/ArtistBottomSheetDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/ArtistBottomSheetDialog.java
@@ -71,7 +71,7 @@ public class ArtistBottomSheetDialog extends BottomSheetDialogFragment implement
         ImageView coverArtist = view.findViewById(R.id.artist_cover_image_view);
         CustomGlideRequest.Builder
                 .from(requireContext(), artistBottomSheetViewModel.getArtist().getCoverArtId(), CustomGlideRequest.ResourceType.Artist)
-                .build()
+                .build(true)
                 .into(coverArtist);
 
         TextView nameArtist = view.findViewById(R.id.song_title_text_view);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/DownloadedBottomSheetDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/DownloadedBottomSheetDialog.java
@@ -79,7 +79,7 @@ public class DownloadedBottomSheetDialog extends BottomSheetDialogFragment imple
 
     private void init(View view) {
         ImageView coverAlbum = view.findViewById(R.id.group_cover_image_view);
-        CustomGlideRequest.Builder.from(requireContext(), songs.get(new Random().nextInt(songs.size())).getCoverArtId(), CustomGlideRequest.ResourceType.Unknown).build().into(coverAlbum);
+        CustomGlideRequest.Builder.from(requireContext(), songs.get(new Random().nextInt(songs.size())).getCoverArtId(), CustomGlideRequest.ResourceType.Unknown).build(true).into(coverAlbum);
 
         TextView groupTitleView = view.findViewById(R.id.group_title_text_view);
         groupTitleView.setText(this.groupTitle);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/PodcastChannelBottomSheetDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/PodcastChannelBottomSheetDialog.java
@@ -64,7 +64,7 @@ public class PodcastChannelBottomSheetDialog extends BottomSheetDialogFragment i
 
         CustomGlideRequest.Builder
                 .from(requireContext(), podcastChannelBottomSheetViewModel.getPodcastChannel().getCoverArtId(), CustomGlideRequest.ResourceType.Podcast)
-                .build()
+                .build(true)
                 .into(coverPodcast);
 
         TextView titlePodcast = view.findViewById(R.id.podcast_title_text_view);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/PodcastEpisodeBottomSheetDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/PodcastEpisodeBottomSheetDialog.java
@@ -66,7 +66,7 @@ public class PodcastEpisodeBottomSheetDialog extends BottomSheetDialogFragment i
 
         CustomGlideRequest.Builder
                 .from(requireContext(), podcastEpisodeBottomSheetViewModel.getPodcastEpisode().getCoverArtId(), CustomGlideRequest.ResourceType.Podcast)
-                .build()
+                .build(true)
                 .into(coverPodcast);
 
         TextView titlePodcast = view.findViewById(R.id.podcast_title_text_view);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/ShareBottomSheetDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/ShareBottomSheetDialog.java
@@ -52,7 +52,7 @@ public class ShareBottomSheetDialog extends BottomSheetDialogFragment implements
 
         CustomGlideRequest.Builder
                 .from(requireContext(), shareBottomSheetViewModel.getShare().getEntries().get(0).getCoverArtId(), CustomGlideRequest.ResourceType.Unknown)
-                .build()
+                .build(true)
                 .into(shareCover);
 
         TextView shareTitle = view.findViewById(R.id.share_title_text_view);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/SongBottomSheetDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/SongBottomSheetDialog.java
@@ -80,7 +80,7 @@ public class SongBottomSheetDialog extends BottomSheetDialogFragment implements 
         ImageView coverSong = view.findViewById(R.id.song_cover_image_view);
         CustomGlideRequest.Builder
                 .from(requireContext(), songBottomSheetViewModel.getSong().getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                .build()
+                .build(true)
                 .into(coverSong);
 
         TextView titleSong = view.findViewById(R.id.song_title_text_view);

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -174,7 +174,7 @@ object Preferences {
 
     @JvmStatic
     fun isInUseServerAddressLocal(): Boolean {
-        return getInUseServerAddress() == getLocalAddress()
+        return getInUseServerAddress() == getLocalAddress() && !getLocalAddress().isNullOrEmpty()
     }
 
     @JvmStatic
@@ -187,7 +187,7 @@ object Preferences {
     fun isServerSwitchable(): Boolean {
         return App.getInstance().preferences.getLong(
                 NEXT_SERVER_SWITCH, 0
-        ) + 15000 < System.currentTimeMillis()
+        ) + 15000 < System.currentTimeMillis() && !getServer().isNullOrEmpty() && !getLocalAddress().isNullOrEmpty()
     }
 
     @JvmStatic


### PR DESCRIPTION
See #246. The images in the discovery section on the front page will be covered as before.

Example:

![vertical-cover-art](https://github.com/CappielloAntonio/tempo/assets/32968142/e00b7037-5fa7-44a0-b9ab-4f587ee0d9f3)
