### PR TITLE
Fix: album page crashes for albums with only one disk and no disk number

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SongHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SongHorizontalAdapter.java
@@ -86,7 +86,7 @@ public class SongHorizontalAdapter extends RecyclerView.Adapter<SongHorizontalAd
         holder.item.songCoverImageView.setVisibility(showCoverArt ? View.VISIBLE : View.INVISIBLE);
 
         if (!showCoverArt &&
-                (position == 0 ||
+                ((position == 0 && songs.get(position).getDiscNumber() != null) ||
                         (position > 0 && songs.get(position - 1) != null &&
                                 songs.get(position - 1).getDiscNumber() != null &&
                                 songs.get(position).getDiscNumber() != null &&

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -174,7 +174,7 @@ object Preferences {
 
     @JvmStatic
     fun isInUseServerAddressLocal(): Boolean {
-        return getInUseServerAddress() == getLocalAddress()
+        return getInUseServerAddress() == getLocalAddress() && !getLocalAddress().isNullOrEmpty()
     }
 
     @JvmStatic
@@ -187,7 +187,7 @@ object Preferences {
     fun isServerSwitchable(): Boolean {
         return App.getInstance().preferences.getLong(
                 NEXT_SERVER_SWITCH, 0
-        ) + 15000 < System.currentTimeMillis()
+        ) + 15000 < System.currentTimeMillis() && !getServer().isNullOrEmpty() && !getLocalAddress().isNullOrEmpty()
     }
 
     @JvmStatic


### PR DESCRIPTION
When opening an album page which only has one disk and no disk number the app crashes.
Related to commit b3b1c5b006f0ba04ce74964ace5731e4c8e9fe0f