### PR TITLE
fix: allow OpenSubsonic extension check on low security servers

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/activity/MainActivity.java
@@ -341,7 +341,7 @@ public class MainActivity extends BaseActivity {
     }
 
     private void pingServer() {
-        if (Preferences.getToken() == null) return;
+        if (Preferences.getToken() == null && Preferences.getPassword() == null) return;
 
         if (Preferences.isInUseServerAddressLocal()) {
             mainViewModel.ping().observe(this, subsonicResponse -> {
@@ -376,7 +376,7 @@ public class MainActivity extends BaseActivity {
     }
 
     private void getOpenSubsonicExtensions() {
-        if (Preferences.getToken() != null) {
+        if (Preferences.getToken() != null || Preferences.getPassword() != null) {
             mainViewModel.getOpenSubsonicExtensions().observe(this, openSubsonicExtensions -> {
                 if (openSubsonicExtensions != null) {
                     Preferences.setOpenSubsonicExtensions(openSubsonicExtensions);


### PR DESCRIPTION
Some servers, such as Nextcloud/Owncloud Music don't support token-based authentication. This made lyrics unavailable to clients connecting to such servers. This commit fixes this behaviour, allowing clients with passwords to ping server to query if it's OpenSubsonic and query all available extensions.