### PR TITLE
Preferences: Prevent empty server string as in use address

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -169,7 +169,10 @@ object Preferences {
 
     @JvmStatic
     fun getInUseServerAddress(): String? {
-        return App.getInstance().preferences.getString(IN_USE_SERVER_ADDRESS, getServer())
+        var inUseServer : String? = App.getInstance().preferences.getString(IN_USE_SERVER_ADDRESS, getServer())
+        if (inUseServer.isNullOrEmpty())
+            return getServer()
+        return inUseServer
     }
 
     @JvmStatic


### PR DESCRIPTION
The function getInUseServerAddress is used to get a valid server address. It is either returning the local address if set or the regular server address.

However, it is possible that an empty string is saved which counts as a valid value and prevents the default value handling from returning getServer().

This commit fixes the behavior that for server profiles where only the server address is set and no local address is set the application crashes on second start with an exception because no valid server address is used (causing an exception in RetroFit).

Fixes "f6b176a3 feat: added the ability for the user to add a local server address and use that address when available"