### PR TITLE
Update network_security_config.xml

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
             <certificates src="user" />


### PR DESCRIPTION
change cleartextTrafficPermitted=true to false

I don't know why I thought this was a great idea at the time, or was it for debugging purpose...dunno. However allowing cleartextTraffic is a very bad idea xD While this doesn't affect Tempo's TLS communication directly this could potentially be an issue for eavesdropping on the communication with self-signed certificates.