### PR TITLE
Support Lowercase ReplayGain Keys

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/util/ReplayGainUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/ReplayGainUtil.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 
 @OptIn(markerClass = UnstableApi.class)
 public class ReplayGainUtil {
-    private static final String[] tags = {"REPLAYGAIN_TRACK_GAIN", "REPLAYGAIN_ALBUM_GAIN", "R128_TRACK_GAIN", "R128_ALBUM_GAIN"};
+    private static final String[] tags = {"REPLAYGAIN_TRACK_GAIN", "replaygain_track_gain", "REPLAYGAIN_ALBUM_GAIN", "replaygain_album_gain", "R128_TRACK_GAIN", "R128_ALBUM_GAIN"};
 
     public static void setReplayGain(ExoPlayer player, Tracks tracks) {
         List<Metadata> metadata = getMetadata(tracks);


### PR DESCRIPTION
I'm using `beets` with my music library and my `.mp3` files have

```
    REPLAYGAIN_ALBUM_GAIN: -7.33 dB
    REPLAYGAIN_ALBUM_PEAK: 1.122018
    replaygain_track_gain: -7.70 dB
    replaygain_track_peak: 0.977237
```

I assume that the lower case keys are not picked up by Tempo and may be contributing to #114. I'm not familiar with Java so I haven't been able to test whether this change does resolve the issue.

---

Thank you for making this program available!