### PR TITLE
Add "Add to queue" menu button to Playlist Page

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
@@ -129,15 +129,20 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
             playlistPageViewModel.getPlaylistSongLiveList().observe(getViewLifecycleOwner(), songs -> {
                 if (isVisible() && getActivity() != null) {
                     DownloadUtil.getDownloadTracker(requireContext()).download(
-                            MappingUtil.mapDownloads(songs),
-                            songs.stream().map(child -> {
-                                Download toDownload = new Download(child);
-                                toDownload.setPlaylistId(playlistPageViewModel.getPlaylist().getId());
-                                toDownload.setPlaylistName(playlistPageViewModel.getPlaylist().getName());
-                                return toDownload;
-                            }).collect(Collectors.toList())
+                        MappingUtil.mapDownloads(songs),
+                        songs.stream().map(child -> {
+                            Download toDownload = new Download(child);
+                            toDownload.setPlaylistId(playlistPageViewModel.getPlaylist().getId());
+                            toDownload.setPlaylistName(playlistPageViewModel.getPlaylist().getName());
+                            return toDownload;
+                        }).collect(Collectors.toList())
                     );
                 }
+            });
+            return true;
+        } else if (item.getItemId() == R.id.action_add_to_queue) {
+            playlistPageViewModel.getPlaylistSongLiveList().observe(getViewLifecycleOwner(), songs -> {
+                MediaManager.enqueue(mediaBrowserListenableFuture, songs, false);
             });
             return true;
         } else if (item.getItemId() == R.id.action_pin_playlist) {

--- a/app/src/main/res/menu/playlist_page_menu.xml
+++ b/app/src/main/res/menu/playlist_page_menu.xml
@@ -13,6 +13,13 @@
         android:icon="@drawable/ic_file_download"
         android:title="@string/menu_download_all_button"
         app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_add_to_queue"
+        android:icon="@drawable/ic_add"
+        android:title="@string/menu_add_to_queue_button"
+        app:showAsAction="never" />
+
     <item
         android:id="@+id/action_pin_playlist"
         android:icon="@drawable/ic_add"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -157,6 +157,7 @@
     <string name="login_title">Subsonic servers</string>
     <string name="login_title_expanded">Subsonic servers</string>
     <string name="media_route_menu_title">Cast</string>
+    <string name="menu_add_to_queue_button">Add to queue</string>
     <string name="menu_add_button">Add</string>
     <string name="menu_download_all_button">Download all</string>
     <string name="menu_download_label">Download</string>


### PR DESCRIPTION
Sometimes it's nice to be able to grab a playlist and chuck it on the back of the current play queue. This PR adds that option.