### PR TITLE
Display toast message after adding a song to a playlist

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/repository/PlaylistRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/PlaylistRepository.java
@@ -1,10 +1,13 @@
 package com.cappielloantonio.tempo.repository;
 
+import android.widget.Toast;
+
 import androidx.annotation.NonNull;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
 import com.cappielloantonio.tempo.App;
+import com.cappielloantonio.tempo.R;
 import com.cappielloantonio.tempo.database.AppDatabase;
 import com.cappielloantonio.tempo.database.dao.PlaylistDao;
 import com.cappielloantonio.tempo.subsonic.base.ApiResponse;
@@ -80,12 +83,12 @@ public class PlaylistRepository {
                 .enqueue(new Callback<ApiResponse>() {
                     @Override
                     public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
-
+                        Toast.makeText(App.getContext(), getString(R.string.playlist_chooser_dialog_toast_add_success), Toast.LENGTH_SHORT).show();
                     }
 
                     @Override
                     public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
-
+                        Toast.makeText(App.getContext(), getString(R.string.playlist_chooser_dialog_toast_add_failure), Toast.LENGTH_SHORT).show();
                     }
                 });
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -186,6 +186,8 @@
     <string name="playlist_chooser_dialog_negative_button">Abbrechen</string>
     <string name="playlist_chooser_dialog_neutral_button">Erstellen</string>
     <string name="playlist_chooser_dialog_title">Zu einer Playliste hinzufügen</string>
+    <string name="playlist_chooser_dialog_toast_add_success">Lied zu Playlist hinzugefügt</string>
+    <string name="playlist_chooser_dialog_toast_add_failure">Titel kann nicht zur Playlist hinzugefügt werden</string>
     <string name="playlist_counted_tracks">%1$d Tracks •  %2$s</string>
     <string name="playlist_duration">Länge  •  %1$s</string>
     <string name="playlist_editor_dialog_action_delete_toast">Zum Löschen lange drücken</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -159,6 +159,8 @@
     <string name="playlist_chooser_dialog_negative_button">Annuler</string>
     <string name="playlist_chooser_dialog_neutral_button">Créer</string>
     <string name="playlist_chooser_dialog_title">Ajouter à une playlist</string>
+    <string name="playlist_chooser_dialog_toast_add_success">Ajout d'une chanson à la playlist</string>
+    <string name="playlist_chooser_dialog_toast_add_failure">Échec de l'ajout d'une chanson à la playlist</string>
     <string name="playlist_counted_tracks">%1$d titres •  %2$s</string>
     <string name="playlist_duration">Durée  •  %1$s</string>
     <string name="playlist_editor_dialog_hint_name">Nom de la playlist</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -188,6 +188,8 @@
 	<string name="playlist_chooser_dialog_negative_button">Annulla</string>
 	<string name="playlist_chooser_dialog_neutral_button">Crea</string>
 	<string name="playlist_chooser_dialog_title">Aggiungi a una playlist</string>
+	<string name="playlist_chooser_dialog_toast_add_success">Aggiunta di un brano alla playlist</string>
+	<string name="playlist_chooser_dialog_toast_add_failure">Impossibile aggiungere un brano alla playlist</string>
 	<string name="playlist_counted_tracks">%1$d brani • %2$s</string>
 	<string name="playlist_duration">Durata  •  %1$s</string>
 	<string name="playlist_editor_dialog_action_delete_toast">Premi a lungo per eliminare</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -161,6 +161,8 @@
     <string name="playlist_chooser_dialog_negative_button">취소</string>
     <string name="playlist_chooser_dialog_neutral_button">생성</string>
     <string name="playlist_chooser_dialog_title">플레이리스트 추가</string>
+    <string name="playlist_chooser_dialog_toast_add_success">재생 목록에 노래 추가</string>
+    <string name="playlist_chooser_dialog_toast_add_failure">재생 목록에 노래를 추가하지 못했습니다.</string>
     <string name="playlist_counted_tracks">%1$d 트랙 •  %2$s</string>
     <string name="playlist_duration">재생시간  •  %1$s</string>
     <string name="playlist_editor_dialog_hint_name">플레이리스트 이름</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -160,6 +160,8 @@
     <string name="playlist_chooser_dialog_negative_button">Cancelar</string>
     <string name="playlist_chooser_dialog_neutral_button">Criar</string>
     <string name="playlist_chooser_dialog_title">Adicionar a uma playlist</string>
+    <string name="playlist_chooser_dialog_toast_add_success">Adicionada playlist de reprodução</string>
+    <string name="playlist_chooser_dialog_toast_add_failure">Falha ao adicionar uma playlist de reprodução</string>
     <string name="playlist_counted_tracks">%1$d faixas •  %2$s</string>
     <string name="playlist_duration">Duração  •  %1$s</string>
     <string name="playlist_editor_dialog_hint_name">Nome da playlist</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -186,6 +186,8 @@
     <string name="playlist_chooser_dialog_negative_button">Отмена</string>
     <string name="playlist_chooser_dialog_neutral_button">Создать</string>
     <string name="playlist_chooser_dialog_title">Добавить в плейлист</string>
+    <string name="playlist_chooser_dialog_toast_add_success">Добавьте песню в плейлист</string>
+    <string name="playlist_chooser_dialog_toast_add_failure">Не удалось добавить песню в список воспроизведения</string>
     <string name="playlist_counted_tracks">%1$d треков • %2$s</string>
     <string name="playlist_duration">Продолжительность • %1$s</string>
     <string name="playlist_editor_dialog_action_delete_toast">Долгое нажатие для удаления</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -165,6 +165,8 @@
     <string name="playlist_chooser_dialog_negative_button">取消</string>
     <string name="playlist_chooser_dialog_neutral_button">新建</string>
     <string name="playlist_chooser_dialog_title">添加到播放列表</string>
+    <string name="playlist_chooser_dialog_toast_add_success">将歌曲添加到播放列表</string>
+    <string name="playlist_chooser_dialog_toast_add_failure">未能将歌曲添加到播放列表</string>
     <string name="playlist_counted_tracks">%1$d 首曲目 • %2$s</string>
     <string name="playlist_duration">持续时间 • %1$s</string>
     <string name="playlist_editor_dialog_hint_name">播放列表名称</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,6 +194,8 @@
     <string name="playlist_chooser_dialog_negative_button">Cancel</string>
     <string name="playlist_chooser_dialog_neutral_button">Create</string>
     <string name="playlist_chooser_dialog_title">Add to a playlist</string>
+    <string name="playlist_chooser_dialog_toast_add_success">Added song to playlist</string>
+    <string name="playlist_chooser_dialog_toast_add_failure">Failed to add song to playlist</string>
     <string name="playlist_counted_tracks">%1$d tracks •  %2$s</string>
     <string name="playlist_duration">Duration  •  %1$s</string>
     <string name="playlist_editor_dialog_action_delete_toast">Long press to delete</string>


### PR DESCRIPTION
Fix to display a Toast message after adding a song to a playlist, to indicate if it was added successfully or if adding the song failed. Also added translations for the new messages
Fixes #369 