### PR TITLE
Fix: Player queue lag, limits

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PlayerSongQueueAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PlayerSongQueueAdapter.java
@@ -1,5 +1,6 @@
 package com.cappielloantonio.tempo.ui.adapter;
 
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -10,6 +11,7 @@ import androidx.appcompat.content.res.AppCompatResources;
 import androidx.media3.session.MediaBrowser;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.bumptech.glide.RequestBuilder;
 import com.cappielloantonio.tempo.R;
 import com.cappielloantonio.tempo.databinding.ItemPlayerQueueSongBinding;
 import com.cappielloantonio.tempo.glide.CustomGlideRequest;
@@ -46,7 +48,7 @@ public class PlayerSongQueueAdapter extends RecyclerView.Adapter<PlayerSongQueue
 
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
-        Child song = songs.get(position);
+        Child song = songs.get(holder.getLayoutPosition());
 
         holder.item.queueSongTitleTextView.setText(song.getTitle());
         holder.item.queueSongSubtitleTextView.setText(
@@ -58,15 +60,21 @@ public class PlayerSongQueueAdapter extends RecyclerView.Adapter<PlayerSongQueue
                 )
         );
 
+        RequestBuilder<Drawable> thumbnail = CustomGlideRequest.Builder
+                        .from(holder.itemView.getContext(), song.getCoverArtId(), CustomGlideRequest.ResourceType.Song)
+                        .build()
+                        .sizeMultiplier(0.1f);
+
         CustomGlideRequest.Builder
                 .from(holder.itemView.getContext(), song.getCoverArtId(), CustomGlideRequest.ResourceType.Song)
                 .build()
+                .thumbnail(thumbnail)
                 .into(holder.item.queueSongCoverImageView);
 
         MediaManager.getCurrentIndex(mediaBrowserListenableFuture, new MediaIndexCallback() {
             @Override
             public void onRecovery(int index) {
-                if (position < index) {
+                if (holder.getLayoutPosition() < index) {
                     holder.item.queueSongTitleTextView.setAlpha(0.2f);
                     holder.item.queueSongSubtitleTextView.setAlpha(0.2f);
                     holder.item.ratingIndicatorImageView.setAlpha(0.2f);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
@@ -193,13 +193,13 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
         playlistPageViewModel.getPlaylistSongLiveList().observe(getViewLifecycleOwner(), songs -> {
             if (bind != null) {
                 bind.playlistPagePlayButton.setOnClickListener(v -> {
-                    MediaManager.startQueue(mediaBrowserListenableFuture, songs.subList(0, Math.min(100, songs.size())), 0);
+                    MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
                     activity.setBottomSheetInPeek(true);
                 });
 
                 bind.playlistPageShuffleButton.setOnClickListener(v -> {
                     Collections.shuffle(songs);
-                    MediaManager.startQueue(mediaBrowserListenableFuture, songs.subList(0, Math.min(100, songs.size())), 0);
+                    MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
                     activity.setBottomSheetInPeek(true);
                 });
             }

--- a/app/src/main/java/com/cappielloantonio/tempo/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/viewmodel/HomeViewModel.java
@@ -94,7 +94,7 @@ public class HomeViewModel extends AndroidViewModel {
     }
 
     public LiveData<List<Child>> getRandomShuffleSample() {
-        return songRepository.getRandomSample(100, null, null);
+        return songRepository.getRandomSample(1000, null, null);
     }
 
     public LiveData<List<Chronology>> getChronologySample(LifecycleOwner owner) {

--- a/app/src/main/res/layout/inner_fragment_player_queue.xml
+++ b/app/src/main/res/layout/inner_fragment_player_queue.xml
@@ -4,39 +4,27 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <TextView
+        android:id="@+id/player_clean_queue_button"
+        style="@style/TitleMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:gravity="center"
+        android:text="@string/player_queue_clean_all_button" />
+
     <com.cappielloantonio.tempo.helper.recyclerview.NestedScrollableHost
-        android:id="@+id/player_queue_nested_scrollable_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.core.widget.NestedScrollView
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/player_queue_recycler_view"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:layout_marginTop="40dp"
+            android:paddingTop="8dp"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="vertical"
-                android:paddingTop="8dp"
-                android:paddingBottom="@dimen/global_padding_bottom">
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/player_queue_recycler_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical" />
-
-                <TextView
-                    android:id="@+id/player_clean_queue_button"
-                    style="@style/TitleMedium"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:layout_marginTop="24dp"
-                    android:text="@string/player_queue_clean_all_button"/>
-
-            </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
     </com.cappielloantonio.tempo.helper.recyclerview.NestedScrollableHost>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton


### PR DESCRIPTION
Fixes #258 fixes #225 

Wrapping a RecyclerView within a NestedScrollView loads each individual item, and for larger playlists this becomes too much for the UI thread which causes major lags.

Luca's fix removes the limits set for playlists, thanks Luca.

My fixes remove the discovery shuffle limit (1000 is a safe default until a better solution is written), as well as fixing the queue XML so that the recyclerview correctly culls items that are out of view. API requests also fire dynamically, as opposed to previously where every item in the queue would immediately have their API requests fired when the queue opens. This is because every item was bound due to the nestedscrollview, which called their onBind method which calls the API requests. 